### PR TITLE
fix: SellingPoints title/subtitle left-align on mobile

### DIFF
--- a/src/components/selling-points/SellingPoints.css
+++ b/src/components/selling-points/SellingPoints.css
@@ -140,11 +140,13 @@
   .selling-points__title {
     font-size: 40px;
     line-height: 45px;
+    text-align: left;
   }
 
   .selling-points__subtitle {
     font-size: 25px;
     line-height: 35px;
+    text-align: left;
   }
 
   .selling-points__image-card-group {


### PR DESCRIPTION
left-align the title and subtitle text of the two SellingPoints components