### PR TITLE
Address a11y and SEO concerns from Lighthouse report (and more!)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,10 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
+    <meta
+      name="description"
+      content="Practicum by Yandex's Apiary program connects new businesses with new developers. Delegate your task today and get started building the website of your dreams, for free."
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
     <!--

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -44,6 +44,7 @@ function App() {
       <div
         onKeyPress={handleNavClick}
         role="button"
+        aria-label="Toggle hamburger menu"
         tabIndex="0"
         className={`header__menu-overlay ${
           isMenuOpen ? 'header__menu-overlay_type_active' : 'header__menu-overlay_type_inactive'

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -43,8 +43,15 @@ function Header({
   return (
     <header className="header" id="header">
       <div className="header__mobile-wrapper">
-        <NavLink className="logo-link" exact to="/" smooth="true" onClick={closeMenu}>
-          <img className="logo" src={Logo} alt="" />
+        <NavLink
+          aria-label="Link back to main page"
+          className="logo-link"
+          exact
+          to="/"
+          smooth="true"
+          onClick={closeMenu}
+        >
+          <img className="logo" src={Logo} alt="Practicum" />
         </NavLink>
         <button
           type="button"
@@ -53,14 +60,14 @@ function Header({
           }`}
           onClick={onNavClick}
         >
-          <img src={Hamburger} alt="" />
+          <img src={Hamburger} alt="Open menu" />
         </button>
         <button
           type="button"
           className={`header__x-icon-button ${isMenuOpen ? 'header__x-icon-button_active' : ''}`}
           onClick={onNavClick}
         >
-          <img src={XIcon} alt="" />
+          <img src={XIcon} alt="Close menu" />
         </button>
       </div>
       <HeaderWrapper

--- a/src/components/homepage/Homepage.js
+++ b/src/components/homepage/Homepage.js
@@ -78,7 +78,7 @@ function Homepage({
         setIsProfessionPageFocused={setIsProfessionPageFocused}
         onCourseClick={onCourseClick}
       />
-      <MessageContainer name="about" />
+      <MessageContainer name="about" handleButtonClick={handleButtonClick} />
       <HowToStart name="start" handleButtonClick={handleButtonClick} />
       <SellingPoints
         title={sellingPointsTitles.chooseUs.title}

--- a/src/components/message/messageContainer.js
+++ b/src/components/message/messageContainer.js
@@ -17,7 +17,7 @@ export default function MessageContainer({ handleButtonClick }) {
         {messages.map((item) => (
           <Item key={item.id} data-aos={item.fade} data-aos-duration="750">
             <Inner direction={item.direction}>
-              <Image displayLogo={item.displayLogo} src={item.backgroundImage} />
+              <Image displayLogo={item.displayLogo} alt="Practicum" src={item.backgroundImage} />
               <Bubble borderRadius={item.borderRadius} backgroundColor={item.backgroundColor}>
                 <Reply text={item.text}>{item.message}</Reply>
               </Bubble>

--- a/src/components/message/messageContainer.js
+++ b/src/components/message/messageContainer.js
@@ -4,7 +4,7 @@ import 'aos/dist/aos.css';
 import { Inner, Section, Container, Item, Bubble, Title, Reply, Image } from './styledMessages';
 import messages from '../../arrays/what-is-practicum';
 
-export default function MessageContainer() {
+export default function MessageContainer({ handleButtonClick }) {
   useEffect(() => {
     AOS.init();
     AOS.refresh();
@@ -30,7 +30,7 @@ export default function MessageContainer() {
           className="hero__cta-wrapper"
           style={{ alignSelf: 'center' }}
         >
-          <button className="hero__cta-button" type="button">
+          <button className="hero__cta-button" type="button" onClick={handleButtonClick}>
             Delegate a task
           </button>
         </div>

--- a/src/components/projects/Projects.js
+++ b/src/components/projects/Projects.js
@@ -30,7 +30,7 @@ export default function Projects({
     } else {
       setHideShowMoreButton(true);
     }
-  }, [projectCollection]);
+  }, [projectCollection, displayedProjects]);
 
   function showMore() {
     if (!isExpanded) {
@@ -39,6 +39,11 @@ export default function Projects({
       setDisplayedProjects(projectCollection.slice(0, displayLimit));
     }
     setExpanded(!isExpanded);
+  }
+
+  function handleCourseButtonClick(course) {
+    onCourseClick(course);
+    setExpanded(false);
   }
 
   return (
@@ -61,7 +66,7 @@ export default function Projects({
                 projectCollection[0].course === 'Web Development' &&
                 'projects__button_active'
               }`}
-              onClick={() => onCourseClick('web')}
+              onClick={() => handleCourseButtonClick('web')}
             >
               Web development
             </button>
@@ -72,7 +77,7 @@ export default function Projects({
                 projectCollection[0].course === 'Data Analysis' &&
                 'projects__button_active'
               }`}
-              onClick={() => onCourseClick('analysis')}
+              onClick={() => handleCourseButtonClick('analysis')}
             >
               Data analysis
             </button>
@@ -83,7 +88,7 @@ export default function Projects({
                 projectCollection[0].course === 'Data Science' &&
                 'projects__button_active'
               }`}
-              onClick={() => onCourseClick('science')}
+              onClick={() => handleCourseButtonClick('science')}
             >
               Data science
             </button>


### PR DESCRIPTION
A breakdown:

SEO:
1) Our SEO was great, but the description of the page was something like `This page was created using Create React App`... not great. I updated it to something cheesy for the Search Engine gods.

Accessibility: 
1) Alt texts where there weren't any 
   - I added Alts to the `X` and `🍔` in the mobile menu. I'm not sure if they were left out intentionally. I found conflicting resources as to whether to use `alt=""` or `alt="Open menu"`. I opted for the Alts just in case, I could be wrong here.
2) Button labels where there weren't any
3) Link names where there weren't any

Extras:
1) Attached the `Messages` "Delegate Task" button to the form
3) Addressed a bug that displayed the wrong text on the "More projects..." button in the project component when switching courses while projects were being show. 
   - Recreating this bug: Go to projects, click "More projects...", switch courses, scroll down and view the button. 
   - It will display "Show less..." while only displaying the default (2) projects, even if there are more to show. When clicking "Show less..." while "less..." is already shown, no more or less projects are show, but the text will update. 
   - Now it should work as intended, as the text will reset when a new course is chosen. 


88 ➡️   98 on the accessibility score baby 🎉

_Oh yeah! The Lighthouse test is kicking a lot of warning with regards to the contrast of colors on our page. If people with impaired sight view our page, they'll have trouble viewing some of the less contrasting colors. That's on the design. We did what we were told. I didn't touch anything there._ 