### PR TITLE
fix: in the why-choose-us data array, change 'Speciality' content to 'Experience'

### DIFF
--- a/src/arrays/why-choose-us.js
+++ b/src/arrays/why-choose-us.js
@@ -1,6 +1,6 @@
 import QualityImage from '../images/star-world.png';
 import ProfessionalismImage from '../images/grad-laptop.png';
-import SpecialityImage from '../images/bees-n-flowers.png';
+import ExperienceImage from '../images/bees-n-flowers.png';
 
 const choose = [
   {
@@ -21,10 +21,10 @@ const choose = [
   },
   {
     id: 3,
-    title: 'Speciality',
+    title: 'Experience',
     subTitle:
       'Our students are already working at Accenture, Tesla, Invitae. Our specialty is practical training for the real world.',
-    image: SpecialityImage,
+    image: ExperienceImage,
     alt: 'flowers',
   },
 ];


### PR DESCRIPTION
I just realized one of the words in the Why Choose Us SellingPoints component was actually "Experience", not "Speciality", so i changed the text content and the name of its corresponding image